### PR TITLE
Fix Bugs when User Manually Edits JSON file

### DIFF
--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -68,10 +68,14 @@ public class StringUtil {
 
     /**
      * Trims value and replaces multiple spaces with a single space
+     * Will return null if value is null
      *
      * @param value a String to be processed
      */
     public static String trimAndReplaceMultipleSpaces(String value) {
+        if (value == null) {
+            return null;
+        }
         return value.trim().replaceAll(" +", " ");
     }
 }

--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -65,4 +65,13 @@ public class StringUtil {
             return false;
         }
     }
+
+    /**
+     * Trims value and replaces multiple spaces with a single space
+     *
+     * @param value a String to be processed
+     */
+    public static String trimAndReplaceMultipleSpaces(String value) {
+        return value.trim().replaceAll(" +", " ");
+    }
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -1,6 +1,7 @@
 package seedu.address.storage;
 
 import static seedu.address.logic.parser.ParserUtil.parseCap;
+import static seedu.address.commons.util.StringUtil.trimAndReplaceMultipleSpaces;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -60,20 +61,20 @@ class JsonAdaptedPerson {
             @JsonProperty("cap") String cap,
             @JsonProperty("university") String university,
             @JsonProperty("major") String major,
-            @JsonProperty("id") String id,
+                             @JsonProperty("id") String id,
             @JsonProperty("title") String title,
             @JsonProperty("tagged") List<JsonAdaptedTag> tagged) {
-        this.name = name;
-        this.phone = phone;
-        this.email = email;
-        this.address = address;
-        this.gender = gender;
-        this.cap = cap;
-        this.graduationDate = graduationDate;
-        this.university = university;
-        this.major = major;
-        this.id = id;
-        this.title = title;
+        this.name = trimAndReplaceMultipleSpaces(name);
+        this.phone = trimAndReplaceMultipleSpaces(phone);
+        this.email = trimAndReplaceMultipleSpaces(email);
+        this.address = trimAndReplaceMultipleSpaces(address);
+        this.gender = trimAndReplaceMultipleSpaces(gender);
+        this.cap = trimAndReplaceMultipleSpaces(cap);
+        this.graduationDate = trimAndReplaceMultipleSpaces(graduationDate);
+        this.university = trimAndReplaceMultipleSpaces(university);
+        this.major = trimAndReplaceMultipleSpaces(major);
+        this.id = trimAndReplaceMultipleSpaces(id);
+        this.title = trimAndReplaceMultipleSpaces(title);
         if (tagged != null) {
             this.tagged.addAll(tagged);
         }
@@ -83,17 +84,17 @@ class JsonAdaptedPerson {
      * Converts a given {@code Person} into this class for Jackson use.
      */
     public JsonAdaptedPerson(Person source) {
-        name = source.getName().fullName;
-        phone = source.getPhone().value;
-        email = source.getEmail().value;
-        address = source.getAddress().value;
-        gender = source.getGender().value;
-        cap = source.getCap().toString();
-        graduationDate = source.getGraduationDate().value;
-        university = source.getUniversity().value;
-        major = source.getMajor().value;
-        id = source.getJob().getId().value;
-        title = source.getJob().getTitle().value;
+        name = trimAndReplaceMultipleSpaces(source.getName().fullName);
+        phone = trimAndReplaceMultipleSpaces(source.getPhone().value);
+        email = trimAndReplaceMultipleSpaces(source.getEmail().value);
+        address = trimAndReplaceMultipleSpaces(source.getAddress().value);
+        gender = trimAndReplaceMultipleSpaces(source.getGender().value);
+        cap = trimAndReplaceMultipleSpaces(source.getCap().toString());
+        graduationDate = trimAndReplaceMultipleSpaces(source.getGraduationDate().value);
+        university = trimAndReplaceMultipleSpaces(source.getUniversity().value);
+        major = trimAndReplaceMultipleSpaces(source.getMajor().value);
+        id = trimAndReplaceMultipleSpaces(source.getJob().getId().value);
+        title = trimAndReplaceMultipleSpaces(source.getJob().getTitle().value);
         tagged.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -60,7 +60,7 @@ class JsonAdaptedPerson {
             @JsonProperty("cap") String cap,
             @JsonProperty("university") String university,
             @JsonProperty("major") String major,
-                             @JsonProperty("id") String id,
+            @JsonProperty("id") String id,
             @JsonProperty("title") String title,
             @JsonProperty("tagged") List<JsonAdaptedTag> tagged) {
         this.name = name;
@@ -113,6 +113,9 @@ class JsonAdaptedPerson {
         if (name == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName()));
         }
+        if (!Name.isWithinLengthLimit(name)) {
+            throw new IllegalValueException(Name.MESSAGE_LENGTH_LIMIT_EXCEEDED);
+        }
         if (!Name.isValidName(name)) {
             throw new IllegalValueException(Name.MESSAGE_CONSTRAINTS);
         }
@@ -120,6 +123,9 @@ class JsonAdaptedPerson {
 
         if (phone == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName()));
+        }
+        if (!Phone.isWithinLengthLimit(phone)) {
+            throw new IllegalValueException(Phone.MESSAGE_LENGTH_LIMIT_EXCEEDED);
         }
         if (!Phone.isValidPhone(phone)) {
             throw new IllegalValueException(Phone.MESSAGE_CONSTRAINTS);
@@ -129,6 +135,9 @@ class JsonAdaptedPerson {
         if (email == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName()));
         }
+        if (!Email.isWithinLengthLimit(email)) {
+            throw new IllegalValueException(Email.MESSAGE_LENGTH_LIMIT_EXCEEDED);
+        }
         if (!Email.isValidEmail(email)) {
             throw new IllegalValueException(Email.MESSAGE_CONSTRAINTS);
         }
@@ -136,6 +145,9 @@ class JsonAdaptedPerson {
 
         if (address == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName()));
+        }
+        if (!Address.isWithinLengthLimit(address)) {
+            throw new IllegalValueException(Address.MESSAGE_LENGTH_LIMIT_EXCEEDED);
         }
         if (!Address.isValidAddress(address)) {
             throw new IllegalValueException(Address.MESSAGE_CONSTRAINTS);
@@ -169,6 +181,9 @@ class JsonAdaptedPerson {
             throw new IllegalValueException(
                 String.format(MISSING_FIELD_MESSAGE_FORMAT, University.class.getSimpleName()));
         }
+        if (!University.isWithinLengthLimit(university)) {
+            throw new IllegalValueException(University.MESSAGE_LENGTH_LIMIT_EXCEEDED);
+        }
         if (!University.isValidUniversity(university)) {
             throw new IllegalValueException(University.MESSAGE_CONSTRAINTS);
         }
@@ -176,6 +191,9 @@ class JsonAdaptedPerson {
 
         if (major == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Major.class.getSimpleName()));
+        }
+        if (!Major.isWithinLengthLimit(major)) {
+            throw new IllegalValueException(Major.MESSAGE_LENGTH_LIMIT_EXCEEDED);
         }
         if (!Major.isValidMajor(major)) {
             throw new IllegalValueException(Major.MESSAGE_CONSTRAINTS);
@@ -185,6 +203,9 @@ class JsonAdaptedPerson {
         if (id == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Id.class.getSimpleName()));
         }
+        if (!Id.isWithinLengthLimit(id)) {
+            throw new IllegalValueException(Id.MESSAGE_LENGTH_LIMIT_EXCEEDED);
+        }
         if (!Id.isValidId(id)) {
             throw new IllegalValueException(Id.MESSAGE_CONSTRAINTS);
         }
@@ -192,6 +213,9 @@ class JsonAdaptedPerson {
 
         if (title == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Title.class.getSimpleName()));
+        }
+        if (!Title.isWithinLengthLimit(title)) {
+            throw new IllegalValueException(Title.MESSAGE_LENGTH_LIMIT_EXCEEDED);
         }
         if (!Title.isValidTitle(title)) {
             throw new IllegalValueException(Title.MESSAGE_CONSTRAINTS);

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -1,7 +1,7 @@
 package seedu.address.storage;
 
-import static seedu.address.logic.parser.ParserUtil.parseCap;
 import static seedu.address.commons.util.StringUtil.trimAndReplaceMultipleSpaces;
+import static seedu.address.logic.parser.ParserUtil.parseCap;
 
 import java.util.ArrayList;
 import java.util.HashSet;

--- a/src/main/java/seedu/address/storage/JsonAdaptedTag.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedTag.java
@@ -1,12 +1,12 @@
 package seedu.address.storage;
 
+import static seedu.address.commons.util.StringUtil.trimAndReplaceMultipleSpaces;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.tag.Tag;
-
-import static seedu.address.commons.util.StringUtil.trimAndReplaceMultipleSpaces;
 
 /**
  * Jackson-friendly version of {@link Tag}.

--- a/src/main/java/seedu/address/storage/JsonAdaptedTag.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedTag.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.tag.Tag;
 
+import static seedu.address.commons.util.StringUtil.trimAndReplaceMultipleSpaces;
+
 /**
  * Jackson-friendly version of {@link Tag}.
  */
@@ -18,14 +20,14 @@ class JsonAdaptedTag {
      */
     @JsonCreator
     public JsonAdaptedTag(String tagName) {
-        this.tagName = tagName;
+        this.tagName = trimAndReplaceMultipleSpaces(tagName);
     }
 
     /**
      * Converts a given {@code Tag} into this class for Jackson use.
      */
     public JsonAdaptedTag(Tag source) {
-        tagName = source.tagName;
+        tagName = trimAndReplaceMultipleSpaces(source.tagName);
     }
 
     @JsonValue

--- a/src/main/java/seedu/address/storage/JsonAdaptedTag.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedTag.java
@@ -39,6 +39,9 @@ class JsonAdaptedTag {
      * @throws IllegalValueException if there were any data constraints violated in the adapted tag.
      */
     public Tag toModelType() throws IllegalValueException {
+        if (!Tag.isWithinLengthLimit(tagName)) {
+            throw new IllegalValueException(Tag.MESSAGE_LENGTH_LIMIT_EXCEEDED);
+        }
         if (!Tag.isValidTagName(tagName)) {
             throw new IllegalValueException(Tag.MESSAGE_CONSTRAINTS);
         }

--- a/src/test/java/seedu/address/commons/util/StringUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/StringUtilTest.java
@@ -1,5 +1,6 @@
 package seedu.address.commons.util;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
@@ -138,6 +139,34 @@ public class StringUtilTest {
     @Test
     public void getDetails_nullGiven_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> StringUtil.getDetails(null));
+    }
+
+    //---------------- Tests for isNonZeroUnsignedInteger --------------------------------------
+
+    @Test
+    public void trimAndReplaceMultipleSpaces() {
+        assertEquals(StringUtil.trimAndReplaceMultipleSpaces(null), null);
+
+        assertEquals(StringUtil.trimAndReplaceMultipleSpaces("test "), "test"); // No spaces
+
+        assertEquals(StringUtil.trimAndReplaceMultipleSpaces("test "),
+                "test"); // 1 trailing space
+        assertEquals(StringUtil.trimAndReplaceMultipleSpaces(" test "),
+                "test"); // 1 Leading and trailing space
+        assertEquals(StringUtil.trimAndReplaceMultipleSpaces("   test     "),
+                "test"); // Multiple Leading and trailing space
+
+        assertEquals(StringUtil.trimAndReplaceMultipleSpaces("test 123"),
+                "test 123"); // 1 space in between
+        assertEquals(StringUtil.trimAndReplaceMultipleSpaces("test      123"),
+                "test 123"); // Multiple spaces in between
+
+        assertEquals(StringUtil.trimAndReplaceMultipleSpaces("   test 123   "),
+                "test 123"); // 1 space in between and multiple leading and trailing spaces
+        assertEquals(StringUtil.trimAndReplaceMultipleSpaces(" test      123 "),
+                "test 123"); // Multiple spaces in between and 1 leading and trailing space
+        assertEquals(StringUtil.trimAndReplaceMultipleSpaces("    test      123    "),
+                "test 123"); // Multiple spaces in between and multiple leading and trailing spaces
     }
 
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -23,6 +23,7 @@ import seedu.address.model.person.Major;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.University;
+import seedu.address.model.tag.Tag;
 
 public class JsonAdaptedPersonTest {
     private static final String INVALID_NAME = "R@chel";
@@ -76,6 +77,22 @@ public class JsonAdaptedPersonTest {
     }
 
     @Test
+    public void toModelType_lengthLimitExceededName_throwsIllegalValueException() {
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME.repeat(100), VALID_PHONE, VALID_EMAIL,
+                VALID_ADDRESS,
+                VALID_GENDER,
+                VALID_GRADUATION_DATE,
+                VALID_CAP,
+                VALID_UNIVERSITY,
+                VALID_MAJOR,
+                VALID_ID,
+                VALID_TITLE,
+                VALID_TAGS);
+        String expectedMessage = Name.MESSAGE_LENGTH_LIMIT_EXCEEDED;
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
     public void toModelType_nullName_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_PHONE, VALID_EMAIL,
                 VALID_ADDRESS,
@@ -104,6 +121,22 @@ public class JsonAdaptedPersonTest {
                 VALID_TITLE,
                 VALID_TAGS);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_lengthLimitExceededPhone_throwsIllegalValueException() {
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE.repeat(100), VALID_EMAIL,
+                VALID_ADDRESS,
+                VALID_GENDER,
+                VALID_GRADUATION_DATE,
+                VALID_CAP,
+                VALID_UNIVERSITY,
+                VALID_MAJOR,
+                VALID_ID,
+                VALID_TITLE,
+                VALID_TAGS);
+        String expectedMessage = Phone.MESSAGE_LENGTH_LIMIT_EXCEEDED;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
@@ -140,6 +173,22 @@ public class JsonAdaptedPersonTest {
     }
 
     @Test
+    public void toModelType_lengthLimitExceededEmail_throwsIllegalValueException() {
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL.repeat(100),
+                VALID_ADDRESS,
+                VALID_GENDER,
+                VALID_GRADUATION_DATE,
+                VALID_CAP,
+                VALID_UNIVERSITY,
+                VALID_MAJOR,
+                VALID_ID,
+                VALID_TITLE,
+                VALID_TAGS);
+        String expectedMessage = Email.MESSAGE_LENGTH_LIMIT_EXCEEDED;
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, null,
                 VALID_ADDRESS,
@@ -168,6 +217,22 @@ public class JsonAdaptedPersonTest {
                 VALID_TITLE,
                 VALID_TAGS);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_lengthLimitExceededAddress_throwsIllegalValueException() {
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL,
+                VALID_ADDRESS.repeat(100),
+                VALID_GENDER,
+                VALID_GRADUATION_DATE,
+                VALID_CAP,
+                VALID_UNIVERSITY,
+                VALID_MAJOR,
+                VALID_ID,
+                VALID_TITLE,
+                VALID_TAGS);
+        String expectedMessage = Address.MESSAGE_LENGTH_LIMIT_EXCEEDED;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
@@ -302,6 +367,22 @@ public class JsonAdaptedPersonTest {
     }
 
     @Test
+    public void toModelType_lengthLimitExceededUniversity_throwsIllegalValueException() {
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL,
+                VALID_ADDRESS,
+                VALID_GENDER,
+                VALID_GRADUATION_DATE,
+                VALID_CAP,
+                VALID_UNIVERSITY.repeat(100),
+                VALID_MAJOR,
+                VALID_ID,
+                VALID_TITLE,
+                VALID_TAGS);
+        String expectedMessage = University.MESSAGE_LENGTH_LIMIT_EXCEEDED;
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
     public void toModelType_nullUniversity_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL,
                 VALID_ADDRESS,
@@ -330,6 +411,22 @@ public class JsonAdaptedPersonTest {
                 VALID_TITLE,
                 VALID_TAGS);
         String expectedMessage = Major.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_lengthLimitExceededMajor_throwsIllegalValueException() {
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL,
+                VALID_ADDRESS,
+                VALID_GENDER,
+                VALID_GRADUATION_DATE,
+                VALID_CAP,
+                VALID_UNIVERSITY,
+                VALID_MAJOR.repeat(100),
+                VALID_ID,
+                VALID_TITLE,
+                VALID_TAGS);
+        String expectedMessage = Major.MESSAGE_LENGTH_LIMIT_EXCEEDED;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
@@ -366,6 +463,22 @@ public class JsonAdaptedPersonTest {
     }
 
     @Test
+    public void toModelType_lengthLimitExceededId_throwsIllegalValueException() {
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL,
+                VALID_ADDRESS,
+                VALID_GENDER,
+                VALID_GRADUATION_DATE,
+                VALID_CAP,
+                VALID_UNIVERSITY,
+                VALID_MAJOR,
+                VALID_ID.repeat(100),
+                VALID_TITLE,
+                VALID_TAGS);
+        String expectedMessage = Id.MESSAGE_LENGTH_LIMIT_EXCEEDED;
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
     public void toModelType_nullId_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL,
                 VALID_ADDRESS,
@@ -394,6 +507,22 @@ public class JsonAdaptedPersonTest {
                 INVALID_TITLE,
                 VALID_TAGS);
         String expectedMessage = Title.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_lengthLimitExceededTitle_throwsIllegalValueException() {
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL,
+                VALID_ADDRESS,
+                VALID_GENDER,
+                VALID_GRADUATION_DATE,
+                VALID_CAP,
+                VALID_UNIVERSITY,
+                VALID_MAJOR,
+                VALID_ID,
+                VALID_TITLE.repeat(100),
+                VALID_TAGS);
+        String expectedMessage = Title.MESSAGE_LENGTH_LIMIT_EXCEEDED;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
@@ -427,7 +556,26 @@ public class JsonAdaptedPersonTest {
                 VALID_ID,
                 VALID_TITLE,
                 invalidTags);
-        assertThrows(IllegalValueException.class, person::toModelType);
+        String expectedMessage = Tag.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_lengthLimitExceededTags_throwsIllegalValueException() {
+        List<JsonAdaptedTag> lengthLimitExceededTags = new ArrayList<>(VALID_TAGS);
+        lengthLimitExceededTags.add(new JsonAdaptedTag(INVALID_TAG.repeat(100)));
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL,
+                VALID_ADDRESS,
+                VALID_GENDER,
+                VALID_GRADUATION_DATE,
+                VALID_CAP,
+                VALID_UNIVERSITY,
+                VALID_MAJOR,
+                VALID_ID,
+                VALID_TITLE,
+                lengthLimitExceededTags);
+        String expectedMessage = Tag.MESSAGE_LENGTH_LIMIT_EXCEEDED;
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
 }


### PR DESCRIPTION
Resolves #164 

- When the user manually edits the JSON file to include multiple spaces and/or leading/trailing spaces, it will be trimmed and multiple spaces will be replaced with a single space
- When the user manually edits the JSON file to include length limit exceeded values, the app will start with a new AddressBook