### PR TITLE
Fix mismatch in stored and displayed Cap value

### DIFF
--- a/src/main/java/seedu/address/model/person/Cap.java
+++ b/src/main/java/seedu/address/model/person/Cap.java
@@ -26,8 +26,10 @@ public class Cap {
         requireNonNull(cap);
         requireNonNull(max);
         checkArgument(isValidCap(cap, max), MESSAGE_CONSTRAINTS);
-        value = cap;
-        maximum = max;
+        String roundedCapValue = String.format("%.2f", cap);
+        String roundedMaxValue = String.format("%.2f", max);
+        value = Double.parseDouble(roundedCapValue);
+        maximum = Double.parseDouble(roundedMaxValue);
     }
 
     /**


### PR DESCRIPTION
Round both cap value and maximum cap value upon creating a `Cap` class.

So now when input of `c/3.9999999/4.0` is given, it will be saved as `4.00/4.00` and will only be found using the argument `find c/4` or `find c/4.0`

Resolves #209 