### PR TITLE
Fix bug with FindCommandParser when empty search values are given

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,9 @@ task coverage(type: JacocoReport) {
 }
 
 dependencies {
+    implementation 'org.jetbrains:annotations:20.1.0'
+    implementation 'org.jetbrains:annotations:20.1.0'
+    implementation 'org.jetbrains:annotations:20.1.0'
     String jUnitVersion = '5.4.0'
     String javaFxVersion = '11'
 

--- a/build.gradle
+++ b/build.gradle
@@ -45,9 +45,6 @@ task coverage(type: JacocoReport) {
 }
 
 dependencies {
-    implementation 'org.jetbrains:annotations:20.1.0'
-    implementation 'org.jetbrains:annotations:20.1.0'
-    implementation 'org.jetbrains:annotations:20.1.0'
     String jUnitVersion = '5.4.0'
     String javaFxVersion = '11'
 

--- a/src/main/java/seedu/address/commons/util/CollectionUtil.java
+++ b/src/main/java/seedu/address/commons/util/CollectionUtil.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
 
@@ -41,7 +42,7 @@ public class CollectionUtil {
      * Iterates through a list of keywords that will be used to search across cap values
      * @throws ParseException
      */
-    public static void checkCapKeywords(String[] keywords) throws ParseException {
+    public static void checkCapKeywords(List<String> keywords) throws ParseException {
         for (String keyword : keywords) {
             try {
                 Double.parseDouble(keyword);

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -16,6 +16,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_UNIVERSITY;
 
 import java.util.Arrays;
+import java.util.List;
 
 import seedu.address.commons.util.CollectionUtil;
 import seedu.address.commons.util.StringUtil;
@@ -39,6 +40,7 @@ import seedu.address.model.person.predicates.UniversityContainsKeywordsPredicate
  * Parses input arguments and creates a new FindCommand object
  */
 public class FindCommandParser implements Parser<FindCommand> {
+    public static final String MESSAGE_EMPTY_FIELD = "Specifier keyword to search with must be provided.";
 
     /**
      * Parses the given {@code String} of arguments in the context of the FindCommand
@@ -68,61 +70,66 @@ public class FindCommandParser implements Parser<FindCommand> {
                 .newListOfContainsKeywordsPredicates();
 
         if (argMultimap.getValue(PREFIX_ADDRESS).isPresent()) {
-            String[] addressKeywords = StringUtil.splitByWhitespace(argMultimap.getValue(PREFIX_ADDRESS).get());
-            predicateList.addPredicate(new AddressContainsKeywordsPredicate(Arrays.asList(addressKeywords)));
+            List<String> addressKeywords = generateKeywords(argMultimap, PREFIX_ADDRESS);
+            predicateList.addPredicate(new AddressContainsKeywordsPredicate(addressKeywords));
         }
         if (argMultimap.getValue(PREFIX_CAP).isPresent()) {
-            String[] capKeywords = StringUtil.splitByWhitespace(argMultimap.getValue(PREFIX_CAP).get());
+            List<String> capKeywords = generateKeywords(argMultimap, PREFIX_CAP);
             CollectionUtil.checkCapKeywords(capKeywords);
-            predicateList.addPredicate(new CapContainsKeywordsPredicate(Arrays.asList(capKeywords)));
+            predicateList.addPredicate(new CapContainsKeywordsPredicate(capKeywords));
         }
         if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
-            String[] emailKeywords = StringUtil.splitByWhitespace(argMultimap.getValue(PREFIX_EMAIL).get());
-            predicateList.addPredicate(new EmailContainsKeywordsPredicate(Arrays.asList(emailKeywords)));
+            List<String> emailKeywords = generateKeywords(argMultimap, PREFIX_EMAIL);
+            predicateList.addPredicate(new EmailContainsKeywordsPredicate(emailKeywords));
         }
         if (argMultimap.getValue(PREFIX_GENDER).isPresent()) {
-            String[] genderKeywords = StringUtil.splitByWhitespace(argMultimap.getValue(PREFIX_GENDER).get());
-            predicateList.addPredicate(new GenderContainsKeywordsPredicate(Arrays.asList(genderKeywords)));
+            List<String> genderKeywords = generateKeywords(argMultimap, PREFIX_GENDER);
+            predicateList.addPredicate(new GenderContainsKeywordsPredicate(genderKeywords));
         }
         if (argMultimap.getValue(PREFIX_GRADUATION_DATE).isPresent()) {
-            String[] graduationDateKeywords = StringUtil.splitByWhitespace(
-                    argMultimap.getValue(PREFIX_GRADUATION_DATE).get());
-            predicateList.addPredicate(new GraduationDateContainsKeywordsPredicate(
-                    Arrays.asList(graduationDateKeywords)));
+            List<String> graduationDateKeywords = generateKeywords(argMultimap, PREFIX_GRADUATION_DATE);
+            predicateList.addPredicate(new GraduationDateContainsKeywordsPredicate(graduationDateKeywords));
         }
         if (argMultimap.getValue(PREFIX_JOB_ID).isPresent()) {
-            String[] jobIdKeywords = StringUtil.splitByWhitespace(argMultimap.getValue(PREFIX_JOB_ID).get());
-            predicateList.addPredicate(new JobIdContainsKeywordsPredicate(Arrays.asList(jobIdKeywords)));
+            List<String> jobIdKeywords = generateKeywords(argMultimap, PREFIX_JOB_ID);
+            predicateList.addPredicate(new JobIdContainsKeywordsPredicate(jobIdKeywords));
         }
         if (argMultimap.getValue(PREFIX_JOB_TITLE).isPresent()) {
-            String[] jobTitleKeywords = StringUtil.splitByWhitespace(argMultimap.getValue(PREFIX_JOB_TITLE).get());
-            predicateList.addPredicate(new JobTitleContainsKeywordsPredicate(Arrays.asList(jobTitleKeywords)));
+            List<String> jobTitleKeywords = generateKeywords(argMultimap, PREFIX_JOB_TITLE);
+            predicateList.addPredicate(new JobTitleContainsKeywordsPredicate(jobTitleKeywords));
         }
         if (argMultimap.getValue(PREFIX_MAJOR).isPresent()) {
-            String[] majorKeywords = StringUtil.splitByWhitespace(argMultimap.getValue(PREFIX_MAJOR).get());
-            predicateList.addPredicate(new MajorContainsKeywordsPredicate(Arrays.asList(majorKeywords)));
+            List<String> majorKeywords = generateKeywords(argMultimap, PREFIX_MAJOR);
+            predicateList.addPredicate(new MajorContainsKeywordsPredicate(majorKeywords));
         }
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
-            String[] nameKeywords = StringUtil.splitByWhitespace(argMultimap.getValue(PREFIX_NAME).get());
-            predicateList.addPredicate(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+            List<String> nameKeywords = generateKeywords(argMultimap, PREFIX_NAME);
+            predicateList.addPredicate(new NameContainsKeywordsPredicate(nameKeywords));
         }
         if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
-            String[] phoneKeywords = StringUtil.splitByWhitespace(argMultimap.getValue(PREFIX_PHONE).get());
-            predicateList.addPredicate(new PhoneContainsKeywordsPredicate(Arrays.asList(phoneKeywords)));
+            List<String> phoneKeywords = generateKeywords(argMultimap, PREFIX_PHONE);
+            predicateList.addPredicate(new PhoneContainsKeywordsPredicate(phoneKeywords));
         }
         if (argMultimap.getValue(PREFIX_TAG).isPresent()) {
-            String[] tagKeywords = StringUtil.splitByWhitespace(argMultimap.getValue(PREFIX_TAG).get());
-            predicateList.addPredicate(new TagContainsKeywordsPredicate(Arrays.asList(tagKeywords)));
+            List<String> tagKeywords = generateKeywords(argMultimap, PREFIX_TAG);
+            predicateList.addPredicate(new TagContainsKeywordsPredicate(tagKeywords));
         }
         if (argMultimap.getValue(PREFIX_UNIVERSITY).isPresent()) {
-            String[] universityKeywords = StringUtil.splitByWhitespace(argMultimap.getValue(PREFIX_UNIVERSITY).get());
-            predicateList.addPredicate(new UniversityContainsKeywordsPredicate(Arrays.asList(universityKeywords)));
+            List<String> universityKeywords = generateKeywords(argMultimap, PREFIX_UNIVERSITY);
+            predicateList.addPredicate(new UniversityContainsKeywordsPredicate(universityKeywords));
         }
         if (!predicateList.hasPredicate()) {
             throw new ParseException(FindCommand.MESSAGE_NO_FIELD_GIVEN);
         }
 
         return new FindCommand(predicateList);
+    }
+    private static List<String> generateKeywords(ArgumentMultimap argMultimap, Prefix prefix) throws ParseException {
+        String keywordsString = argMultimap.getValue(prefix).get();
+        if (keywordsString.isEmpty()) {
+            throw new ParseException(MESSAGE_EMPTY_FIELD);
+        }
+        return Arrays.asList(StringUtil.splitByWhitespace(keywordsString));
     }
 
 }

--- a/src/test/java/seedu/address/commons/util/CollectionUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/CollectionUtilTest.java
@@ -87,11 +87,8 @@ public class CollectionUtilTest {
 
     @Test
     public void invalidCap_throwsParseException() {
-        String[] alphanumericKeywords = {"asdf", "3a", "a2"};
-        assertThrows(ParseException.class, () -> checkCapKeywords(alphanumericKeywords));
-
-        String[] symbolKeywords = {"!", "@", "#", "/", "3.0/", "/3.0"};
-        assertThrows(ParseException.class, () -> checkCapKeywords(symbolKeywords));
+        assertThrows(ParseException.class, () -> checkCapKeywords(Arrays.asList("asdf", "3a", "a2")));
+        assertThrows(ParseException.class, () -> checkCapKeywords(Arrays.asList("!", "@", "#", "/", "3.0/", "/3.0")));
     }
 
     /**

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -45,7 +45,8 @@ public class FindCommandParserTest {
         assertParseFailure(parser, "a/Main Street c/3.5 e/", FindCommandParser.MESSAGE_EMPTY_FIELD);
         assertParseFailure(parser, "a/Main Street c/3.5 e/gmail g/", FindCommandParser.MESSAGE_EMPTY_FIELD);
         assertParseFailure(parser, "a/Main Street c/3.5 e/gmail g/Female gd/", FindCommandParser.MESSAGE_EMPTY_FIELD);
-        assertParseFailure(parser, "a/Main Street c/3.5 e/gmail g/Female gd/05-2024 ji/", FindCommandParser.MESSAGE_EMPTY_FIELD);
+        assertParseFailure(parser, "a/Main Street c/3.5 e/gmail g/Female gd/05-2024 "
+                + "ji/", FindCommandParser.MESSAGE_EMPTY_FIELD);
         assertParseFailure(parser, "a/Main Street c/3.5 e/gmail g/Female gd/05-2024 "
                 + "ji/JID1234 jt/", FindCommandParser.MESSAGE_EMPTY_FIELD);
         assertParseFailure(parser, "a/Main Street c/3.5 e/gmail g/Female gd/05-2024 "
@@ -53,9 +54,11 @@ public class FindCommandParserTest {
         assertParseFailure(parser, "a/Main Street c/3.5 e/gmail g/Female gd/05-2024 "
                 + "ji/JID1234 jt/Software Engineer m/Computer Science n/", FindCommandParser.MESSAGE_EMPTY_FIELD);
         assertParseFailure(parser, "a/Main Street c/3.5 e/gmail g/Female gd/05-2024 "
-                + "ji/JID1234 jt/Software Engineer m/Computer Science n/Alice Bob t/", FindCommandParser.MESSAGE_EMPTY_FIELD);
+                + "ji/JID1234 jt/Software Engineer m/Computer Science "
+                + "n/Alice Bob t/", FindCommandParser.MESSAGE_EMPTY_FIELD);
         assertParseFailure(parser, "a/Main Street c/3.5 e/gmail g/Female gd/05-2024 "
-                + "ji/JID1234 jt/Software Engineer m/Computer Science n/Alice Bob t/offered KIV u/", FindCommandParser.MESSAGE_EMPTY_FIELD);
+                + "ji/JID1234 jt/Software Engineer m/Computer Science "
+                + "n/Alice Bob t/offered KIV u/", FindCommandParser.MESSAGE_EMPTY_FIELD);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -39,6 +39,26 @@ public class FindCommandParserTest {
     }
 
     @Test
+    public void parse_emptySpecifierKeyword_throwsParseException() {
+        assertParseFailure(parser, "a/", FindCommandParser.MESSAGE_EMPTY_FIELD);
+        assertParseFailure(parser, "a/Main Street c/", FindCommandParser.MESSAGE_EMPTY_FIELD);
+        assertParseFailure(parser, "a/Main Street c/3.5 e/", FindCommandParser.MESSAGE_EMPTY_FIELD);
+        assertParseFailure(parser, "a/Main Street c/3.5 e/gmail g/", FindCommandParser.MESSAGE_EMPTY_FIELD);
+        assertParseFailure(parser, "a/Main Street c/3.5 e/gmail g/Female gd/", FindCommandParser.MESSAGE_EMPTY_FIELD);
+        assertParseFailure(parser, "a/Main Street c/3.5 e/gmail g/Female gd/05-2024 ji/", FindCommandParser.MESSAGE_EMPTY_FIELD);
+        assertParseFailure(parser, "a/Main Street c/3.5 e/gmail g/Female gd/05-2024 "
+                + "ji/JID1234 jt/", FindCommandParser.MESSAGE_EMPTY_FIELD);
+        assertParseFailure(parser, "a/Main Street c/3.5 e/gmail g/Female gd/05-2024 "
+                + "ji/JID1234 jt/Software Engineer m/", FindCommandParser.MESSAGE_EMPTY_FIELD);
+        assertParseFailure(parser, "a/Main Street c/3.5 e/gmail g/Female gd/05-2024 "
+                + "ji/JID1234 jt/Software Engineer m/Computer Science n/", FindCommandParser.MESSAGE_EMPTY_FIELD);
+        assertParseFailure(parser, "a/Main Street c/3.5 e/gmail g/Female gd/05-2024 "
+                + "ji/JID1234 jt/Software Engineer m/Computer Science n/Alice Bob t/", FindCommandParser.MESSAGE_EMPTY_FIELD);
+        assertParseFailure(parser, "a/Main Street c/3.5 e/gmail g/Female gd/05-2024 "
+                + "ji/JID1234 jt/Software Engineer m/Computer Science n/Alice Bob t/offered KIV u/", FindCommandParser.MESSAGE_EMPTY_FIELD);
+    }
+
+    @Test
     public void parse_validArgs_returnsFindCommand() {
         ListOfContainsKeywordsPredicates predicateList = ListOfContainsKeywordsPredicates
                 .newListOfContainsKeywordsPredicates();


### PR DESCRIPTION
Resolves #189

When empty values are given to be searched, exception is thrown. eg. `n/`
This fix does the following:
* Shows user appropriate error when an empty value to be searched for is given
* Refactors FindCommandParser for neatness
* Adds test cases for empty values searches.
