### PR TITLE
Find bug: invalid prefix

### DIFF
--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -49,12 +49,7 @@ public class FindCommandParser implements Parser<FindCommand> {
      */
     public FindCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        String trimmedArgs = args.trim();
-        if (trimmedArgs.isEmpty()) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
-        }
-        String argToTokenize = "0 " + trimmedArgs; // dummy preamble for tokenizer
+        String argToTokenize = "1 " + args; // dummy preamble for tokenizer
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(argToTokenize, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
                         PREFIX_ADDRESS,
@@ -66,6 +61,13 @@ public class FindCommandParser implements Parser<FindCommand> {
                         PREFIX_JOB_ID,
                         PREFIX_JOB_TITLE,
                         PREFIX_TAG);
+
+        try {
+            ParserUtil.parseIndex(argMultimap.getPreamble()); // catches invalid values entered before prefix
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE), pe);
+        }
+
         ListOfContainsKeywordsPredicates predicateList = ListOfContainsKeywordsPredicates
                 .newListOfContainsKeywordsPredicates();
 

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -30,12 +30,13 @@ public class FindCommandParserTest {
 
     @Test
     public void parse_emptyArg_throwsParseException() {
-        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "     ", String.format(MESSAGE_NO_FIELD_GIVEN, FindCommand.MESSAGE_USAGE));
     }
 
     @Test
     public void parse_emptyFieldSpecifier_throwsParseException() {
-        assertParseFailure(parser, "alice Bob ", String.format(MESSAGE_NO_FIELD_GIVEN, FindCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "alice Bob ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
     }
 
     @Test
@@ -44,21 +45,24 @@ public class FindCommandParserTest {
         assertParseFailure(parser, "a/Main Street c/", FindCommandParser.MESSAGE_EMPTY_FIELD);
         assertParseFailure(parser, "a/Main Street c/3.5 e/", FindCommandParser.MESSAGE_EMPTY_FIELD);
         assertParseFailure(parser, "a/Main Street c/3.5 e/gmail g/", FindCommandParser.MESSAGE_EMPTY_FIELD);
-        assertParseFailure(parser, "a/Main Street c/3.5 e/gmail g/Female gd/", FindCommandParser.MESSAGE_EMPTY_FIELD);
-        assertParseFailure(parser, "a/Main Street c/3.5 e/gmail g/Female gd/05-2024 "
-                + "ji/", FindCommandParser.MESSAGE_EMPTY_FIELD);
-        assertParseFailure(parser, "a/Main Street c/3.5 e/gmail g/Female gd/05-2024 "
-                + "ji/JID1234 jt/", FindCommandParser.MESSAGE_EMPTY_FIELD);
-        assertParseFailure(parser, "a/Main Street c/3.5 e/gmail g/Female gd/05-2024 "
-                + "ji/JID1234 jt/Software Engineer m/", FindCommandParser.MESSAGE_EMPTY_FIELD);
-        assertParseFailure(parser, "a/Main Street c/3.5 e/gmail g/Female gd/05-2024 "
-                + "ji/JID1234 jt/Software Engineer m/Computer Science n/", FindCommandParser.MESSAGE_EMPTY_FIELD);
-        assertParseFailure(parser, "a/Main Street c/3.5 e/gmail g/Female gd/05-2024 "
-                + "ji/JID1234 jt/Software Engineer m/Computer Science "
-                + "n/Alice Bob t/", FindCommandParser.MESSAGE_EMPTY_FIELD);
-        assertParseFailure(parser, "a/Main Street c/3.5 e/gmail g/Female gd/05-2024 "
-                + "ji/JID1234 jt/Software Engineer m/Computer Science "
-                + "n/Alice Bob t/offered KIV u/", FindCommandParser.MESSAGE_EMPTY_FIELD);
+        assertParseFailure(parser, "a/Main Street c/3.5 e/gmail g/Female gd/",
+                FindCommandParser.MESSAGE_EMPTY_FIELD);
+        assertParseFailure(parser, "a/Main Street c/3.5 e/gmail g/Female gd/05-2024 ji/",
+                FindCommandParser.MESSAGE_EMPTY_FIELD);
+        assertParseFailure(parser, "a/Main Street c/3.5 e/gmail g/Female gd/05-2024 ji/JID1234 jt/",
+                FindCommandParser.MESSAGE_EMPTY_FIELD);
+        assertParseFailure(parser, "a/Main Street c/3.5 e/gmail g/Female gd/05-2024 ji/JID1234 "
+                + "jt/Software Engineer m/",
+                FindCommandParser.MESSAGE_EMPTY_FIELD);
+        assertParseFailure(parser, "a/Main Street c/3.5 e/gmail g/Female gd/05-2024 ji/JID1234 "
+                + "jt/Software Engineer m/Computer Science n/",
+                FindCommandParser.MESSAGE_EMPTY_FIELD);
+        assertParseFailure(parser, "a/Main Street c/3.5 e/gmail g/Female gd/05-2024 ji/JID1234 "
+                + "jt/Software Engineer m/Computer Science  n/Alice Bob t/",
+                FindCommandParser.MESSAGE_EMPTY_FIELD);
+        assertParseFailure(parser, "a/Main Street c/3.5 e/gmail g/Female gd/05-2024 ji/JID1234 "
+                + "jt/Software Engineer m/Computer Science  n/Alice Bob t/offered KIV u/",
+                FindCommandParser.MESSAGE_EMPTY_FIELD);
     }
 
     @Test


### PR DESCRIPTION
Resolves #202 

Throws an error correctly now if an invalid prefix is input BEFORE the first valid prefix.

Based on our discussion, decided to fix this bug using option 1 for consistency with the add and edit commands, 
as it will also doesn't affect our ability to search for terms like "s/o"
